### PR TITLE
#33: Hotkey control events

### DIFF
--- a/components/Modal/Modal.tsx
+++ b/components/Modal/Modal.tsx
@@ -15,22 +15,22 @@ export interface IModalProps extends React.PropsWithChildren<{}> {
 }
 
 const Modal: React.FC<IModalProps> = ({ children, onClose }) => {
-  const rootRef = useRef<HTMLDivElement>();
+  const closeButtonRef = useRef<HTMLButtonElement>();
 
   const handleClick = () => {
     onClose();
   };
 
   useEffect(() => {
-    rootRef.current.focus();
-    rootRef.current.blur();
+    closeButtonRef.current.focus();
+    closeButtonRef.current.blur();
   });
 
   return (
     <div className={styles.root}>
       <ThemeVars theme="Modal" cssProps={styles} />
       <IconButton
-        ref={rootRef}
+        ref={closeButtonRef}
         type="button"
         className={styles.closeButton}
         onClick={handleClick}

--- a/components/Modal/Modal.tsx
+++ b/components/Modal/Modal.tsx
@@ -4,7 +4,7 @@
  *
  */
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import ThemeVars from '@components/ThemeVars';
 import IconButton from '@components/IconButton';
 import CloseIcon from '@svg/icons/Close.svg';
@@ -15,22 +15,30 @@ export interface IModalProps extends React.PropsWithChildren<{}> {
 }
 
 const Modal: React.FC<IModalProps> = ({ children, onClose }) => {
+  const rootRef = useRef<HTMLDivElement>();
+
   const handleClick = () => {
     onClose();
   };
 
+  useEffect(() => {
+    rootRef.current.focus();
+    rootRef.current.blur();
+  });
+
   return (
     <div className={styles.root}>
       <ThemeVars theme="Modal" cssProps={styles} />
-      {children}
-
       <IconButton
+        ref={rootRef}
         type="button"
         className={styles.closeButton}
         onClick={handleClick}
       >
         <CloseIcon />
       </IconButton>
+
+      {children}
     </div>
   );
 };

--- a/components/Player/CoverArt/CoverArt.tsx
+++ b/components/Player/CoverArt/CoverArt.tsx
@@ -5,7 +5,6 @@
 
 import type React from 'react';
 import { useContext } from 'react';
-import { PlayerActionTypes } from '@states/player/Player.actions';
 import PrxImage from '@components/PrxImage';
 import PlayerContext from '@contexts/PlayerContext';
 import styles from './CoverArt.module.scss';
@@ -13,12 +12,12 @@ import styles from './CoverArt.module.scss';
 export interface ICoverArtProps {}
 
 const CoverArt: React.FC<ICoverArtProps> = () => {
-  const { state, dispatch } = useContext(PlayerContext);
+  const { state, togglePlayPause } = useContext(PlayerContext);
   const { tracks, currentTrackIndex } = state;
   const { imageUrl, title } = tracks[currentTrackIndex];
 
   const handleClick = () => {
-    dispatch({ type: PlayerActionTypes.PLAYER_TOGGLE_PLAYING });
+    togglePlayPause();
   };
 
   return (

--- a/components/Player/ForwardButton/ForwardButton.tsx
+++ b/components/Player/ForwardButton/ForwardButton.tsx
@@ -7,7 +7,6 @@
 import type React from 'react';
 import { useContext } from 'react';
 import PlayerContext from '@contexts/PlayerContext';
-import { PlayerActionTypes } from '@states/player/Player.actions';
 import IconButton from '@components/IconButton';
 import ForwardIcon from '@svg/icons/Forward.svg';
 
@@ -15,13 +14,10 @@ export interface IForwardButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 const ForwardButton: React.FC<IForwardButtonProps> = ({ ...props }) => {
-  const { audioElm, dispatch } = useContext(PlayerContext);
+  const { seekBy } = useContext(PlayerContext);
 
   const handleClick = () => {
-    dispatch({
-      type: PlayerActionTypes.PLAYER_UPDATE_CURRENT_TIME,
-      payload: Math.min(audioElm.currentTime + 30, audioElm.duration)
-    });
+    seekBy(30);
   };
 
   return (

--- a/components/Player/NextButton/NextButton.tsx
+++ b/components/Player/NextButton/NextButton.tsx
@@ -6,7 +6,6 @@
 import type React from 'react';
 import { useContext } from 'react';
 import PlayerContext from '@contexts/PlayerContext';
-import { PlayerActionTypes } from '@states/player/Player.actions';
 import IconButton from '@components/IconButton';
 import NextIcon from '@svg/icons/Next.svg';
 
@@ -14,12 +13,10 @@ export interface INextButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 const NextButton: React.FC<INextButtonProps> = ({ ...props }) => {
-  const { dispatch } = useContext(PlayerContext);
+  const { nextTrack } = useContext(PlayerContext);
 
   const handleClick = () => {
-    dispatch({
-      type: PlayerActionTypes.PLAYER_NEXT_TRACK
-    });
+    nextTrack();
   };
 
   return (

--- a/components/Player/PlayButton/PlayButton.tsx
+++ b/components/Player/PlayButton/PlayButton.tsx
@@ -6,7 +6,6 @@
 import type React from 'react';
 import { useContext } from 'react';
 import PlayerContext from '@contexts/PlayerContext';
-import { PlayerActionTypes } from '@states/player/Player.actions';
 import ThemeVars from '@components/ThemeVars';
 import IconButton from '@components/IconButton';
 import PlayArrowIcon from '@svg/icons/PlayArrow.svg';
@@ -17,11 +16,11 @@ export interface IPlayButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 const PlayButton: React.FC<IPlayButtonProps> = ({ className, ...props }) => {
-  const { state, dispatch } = useContext(PlayerContext);
+  const { state, togglePlayPause } = useContext(PlayerContext);
   const { playing } = state;
 
   const handleClick = () => {
-    dispatch({ type: PlayerActionTypes.PLAYER_TOGGLE_PLAYING });
+    togglePlayPause();
   };
 
   return (

--- a/components/Player/Player.tsx
+++ b/components/Player/Player.tsx
@@ -19,6 +19,10 @@ export interface IPlayerProps extends React.PropsWithChildren<{}> {
   imageUrl?: string;
 }
 
+export interface KeyboardEventWithTarget extends KeyboardEvent {
+  target: HTMLElement;
+}
+
 const Player: React.FC<IPlayerProps> = ({
   audio,
   startIndex,
@@ -33,19 +37,95 @@ const Player: React.FC<IPlayerProps> = ({
     ...(startIndex && { currentTrackIndex: startIndex })
   });
   const { playing, currentTrackIndex, currentTime } = state;
+  const currentTrack = tracks[currentTrackIndex];
+  const isLastTrack = currentTrackIndex === tracks.length - 1;
+  const { url } = currentTrack;
+
+  const toggleMute = () => {
+    dispatch({
+      type: PlayerActionTypes.PLAYER_TOGGLE_MUTED
+    });
+  };
+
+  const play = () => {
+    dispatch({ type: PlayerActionTypes.PLAYER_PLAY });
+  };
+
+  const pause = () => {
+    dispatch({ type: PlayerActionTypes.PLAYER_PAUSE });
+  };
+
+  const togglePlayPause = () => {
+    dispatch({ type: PlayerActionTypes.PLAYER_TOGGLE_PLAYING });
+  };
+
+  const boundedTime = useCallback(
+    (time: number) => Math.min(Math.max(0.00001, time), audioElm.duration),
+    [audioElm?.duration]
+  );
+
+  const seekTo = useCallback(
+    (time: number) => {
+      dispatch({
+        type: PlayerActionTypes.PLAYER_UPDATE_CURRENT_TIME,
+        payload: boundedTime(time)
+      });
+    },
+    [boundedTime]
+  );
+
+  const seekBy = useCallback(
+    (seconds: number) => {
+      seekTo(audioElm.currentTime + seconds);
+    },
+    [audioElm?.currentTime, seekTo]
+  );
+
+  const seekToRelative = useCallback(
+    (ratio: number) => {
+      seekTo(audioElm.duration * ratio);
+    },
+    [audioElm?.duration, seekTo]
+  );
+
+  const setTrack = (index: number) => {
+    dispatch({
+      type: PlayerActionTypes.PLAYER_UPDATE_CURRENT_TRACK_INDEX,
+      payload: index
+    });
+  };
+
+  const previousTrack = () => {
+    dispatch({
+      type: PlayerActionTypes.PLAYER_PREVIOUS_TRACK
+    });
+  };
+
+  const nextTrack = () => {
+    dispatch({
+      type: PlayerActionTypes.PLAYER_NEXT_TRACK
+    });
+  };
+
   const playerContextValue = useMemo(
     () => ({
       audioElm,
       imageUrl,
       state,
-      dispatch
+      dispatch,
+      play,
+      pause,
+      togglePlayPause,
+      toggleMute,
+      seekTo,
+      seekBy,
+      seekToRelative,
+      setTrack,
+      previousTrack,
+      nextTrack
     }),
-    [audioElm, imageUrl, state]
+    [audioElm, imageUrl, seekBy, seekTo, seekToRelative, state]
   );
-  const currentTrack = tracks[currentTrackIndex];
-  const isLastTrack = currentTrackIndex === tracks.length - 1;
-  const { url } = currentTrack;
-  // variable for the current timestamp to scrub position?
 
   const handlePlay = useCallback(() => {
     dispatch({ type: PlayerActionTypes.PLAYER_PLAY });
@@ -80,6 +160,89 @@ const Player: React.FC<IPlayerProps> = ({
     }
   }, [isLastTrack]);
 
+  const handleHotkey = useCallback(
+    (event: KeyboardEventWithTarget) => {
+      const key = event.code || event.key;
+      switch (key) {
+        case 'KeyS':
+          audioElm.playbackRate = 3 - audioElm.playbackRate;
+          break;
+        case 'KeyM':
+          toggleMute();
+          break;
+        case 'Space':
+          if (event.target.nodeName !== 'BUTTON') {
+            togglePlayPause();
+          }
+          break;
+        case 'KeyK':
+          togglePlayPause();
+          break;
+        case 'KeyJ':
+          seekBy(-10);
+          break;
+        case 'KeyL':
+          seekBy(10);
+          break;
+        case 'ArrowLeft':
+          seekBy(-5);
+          break;
+        case 'ArrowRight':
+          seekBy(5);
+          break;
+        case 'Comma':
+          if (!playing) {
+            seekBy(-1 / 30);
+          }
+          break;
+        case 'Period':
+          if (!playing) {
+            seekBy(1 / 30);
+          }
+          break;
+        case 'Home':
+          seekTo(0);
+          break;
+        case 'End':
+          seekToRelative(1);
+          break;
+        case 'Digit1':
+          seekToRelative(0.1);
+          break;
+        case 'Digit2':
+          seekToRelative(0.2);
+          break;
+        case 'Digit3':
+          seekToRelative(0.3);
+          break;
+        case 'Digit4':
+          seekToRelative(0.4);
+          break;
+        case 'Digit5':
+          seekToRelative(0.5);
+          break;
+        case 'Digit6':
+          seekToRelative(0.6);
+          break;
+        case 'Digit7':
+          seekToRelative(0.7);
+          break;
+        case 'Digit8':
+          seekToRelative(0.8);
+          break;
+        case 'Digit9':
+          seekToRelative(0.9);
+          break;
+        case 'Digit0':
+          seekTo(0);
+          break;
+        default:
+          break;
+      }
+    },
+    [audioElm, playing, seekBy, seekTo, seekToRelative]
+  );
+
   useEffect(() => {
     // Setup event handlers on audio element.
     audioElm?.addEventListener('play', handlePlay);
@@ -87,14 +250,25 @@ const Player: React.FC<IPlayerProps> = ({
     audioElm?.addEventListener('loadedmetadata', handleLoadedMetadata);
     audioElm?.addEventListener('ended', handleEnded);
 
+    window.addEventListener('keydown', handleHotkey);
+
     return () => {
       // Cleanup event handlers between dependency changes.
       audioElm?.removeEventListener('play', handlePlay);
       audioElm?.removeEventListener('pause', handlePause);
       audioElm?.removeEventListener('loadedmetadata', handleLoadedMetadata);
       audioElm?.removeEventListener('ended', handleEnded);
+
+      window.removeEventListener('keydown', handleHotkey);
     };
-  }, [audioElm, handleLoadedMetadata, handlePause, handlePlay, handleEnded]);
+  }, [
+    audioElm,
+    handleLoadedMetadata,
+    handlePause,
+    handlePlay,
+    handleEnded,
+    handleHotkey
+  ]);
 
   useEffect(() => {
     if (!playing) {

--- a/components/Player/PlayerProgress/PlayerProgress.tsx
+++ b/components/Player/PlayerProgress/PlayerProgress.tsx
@@ -42,11 +42,7 @@ const PlayerProgress: React.FC<IPlayerProgressProps> = ({
     playerProgressInitialState
   );
   const { scrubPosition, played, playedSeconds, duration } = state;
-  const {
-    audioElm,
-    state: playerState,
-    dispatch: playerDispatch
-  } = useContext(PlayerContext);
+  const { audioElm, state: playerState, seekTo } = useContext(PlayerContext);
   const {
     currentTrackIndex,
     tracks,
@@ -150,17 +146,14 @@ const PlayerProgress: React.FC<IPlayerProgressProps> = ({
    * @param e Pointer Event
    */
   const handlePointerUp = useCallback(() => {
-    playerDispatch({
-      type: PlayerActionTypes.PLAYER_UPDATE_CURRENT_TIME,
-      payload: scrubPosition * audioElm.duration
-    });
+    seekTo(scrubPosition * audioElm.duration);
 
     dispatch({
       type: PlayerActionTypes.PLAYER_UPDATE_PROGRESS_TO_SCRUB_POSITION
     });
 
     trackRef.current.removeEventListener('pointermove', handlePointerMove);
-  }, [audioElm.duration, handlePointerMove, playerDispatch, scrubPosition]);
+  }, [audioElm.duration, handlePointerMove, scrubPosition, seekTo]);
 
   /**
    * Window resize handler.

--- a/components/Player/PlayerProgress/PlayerProgress.tsx
+++ b/components/Player/PlayerProgress/PlayerProgress.tsx
@@ -86,6 +86,9 @@ const PlayerProgress: React.FC<IPlayerProgressProps> = ({
     });
   }, []);
 
+  /**
+   * Update player progress visuals.
+   */
   const updateProgress = useCallback(
     (seconds?: number) => {
       const { currentTime: ct, duration: d } = audioElm;
@@ -171,15 +174,9 @@ const PlayerProgress: React.FC<IPlayerProgressProps> = ({
    */
   useEffect(() => {
     if (playerCurrentTime !== null) {
-      dispatch({
-        type: PlayerActionTypes.PLAYER_UPDATE_PROGRESS,
-        payload: {
-          playedSeconds: playerCurrentTime,
-          played: playerCurrentTime / duration
-        }
-      });
+      updateProgress(playerCurrentTime);
     }
-  }, [duration, playerCurrentTime]);
+  }, [duration, playerCurrentTime, updateProgress]);
 
   /**
    * Setup update interval.

--- a/components/Player/Playlist/Playlist.module.scss
+++ b/components/Player/Playlist/Playlist.module.scss
@@ -62,6 +62,8 @@ $playlist-header-text-color: $white;
   align-content: start;
 }
 
+@mixin trackAccentBackground {
+}
 .track {
   position: relative;
   display: grid;
@@ -76,7 +78,7 @@ $playlist-header-text-color: $white;
   border-bottom-color: var(--playlist-divider-color);
 
   color: var(--playlist-text-color);
-  font-size: 1rem;
+  font-size: clamp(0.8rem, 4.5vw, 1rem);
 
   &:last-of-type {
     border-bottom: none;
@@ -98,24 +100,24 @@ $playlist-header-text-color: $white;
   &:focus-visible {
     &::before {
       opacity: 0.15;
-
-      background-color: var(
-        --accent-color,
-        var(--playlist-background-color--active)
-      );
     }
   }
 
   &.isCurrentTrack {
     color: var(--playlist-text-color--active);
 
+    &::before {
+      opacity: 0.35;
+    }
+  }
+
+  &.isCurrentTrack,
+  &:focus-visible {
     & > * {
       position: relative;
     }
 
     &::before {
-      opacity: 0.35;
-
       background-color: var(
         --accent-color,
         var(--playlist-background-color--active)

--- a/components/Player/Playlist/Playlist.tsx
+++ b/components/Player/Playlist/Playlist.tsx
@@ -11,7 +11,6 @@ import convertDurationStringToIntegerArray from '@lib/convert/string/convertDura
 import formatDurationParts from '@lib/format/time/formatDurationParts';
 import sumDurationParts from '@lib/math/time/sumDurationParts';
 import PlayerContext from '@contexts/PlayerContext';
-import { PlayerActionTypes } from '@states/player/Player.actions';
 import PrxImage from '@components/PrxImage';
 import ThemeVars from '@components/ThemeVars';
 import ExplicitIcon from '@svg/icons/Explicit.svg';
@@ -27,7 +26,8 @@ const Playlist: React.FC<IPlaylistProps> = ({ className, ...props }) => {
   const {
     imageUrl: defaultThumbUrl,
     state,
-    dispatch
+    play,
+    setTrack
   } = useContext(PlayerContext);
   const { tracks, currentTrackIndex } = state;
   const rootRef = useRef(null);
@@ -47,16 +47,11 @@ const Playlist: React.FC<IPlaylistProps> = ({ className, ...props }) => {
   }, []);
 
   const handleTrackClick = (index: number) => () => {
-    dispatch({
-      type: PlayerActionTypes.PLAYER_UPDATE_CURRENT_TRACK_INDEX,
-      payload: index
-    });
+    setTrack(index);
 
     // Delay playing to give audio a chance to update src.
     setTimeout(() => {
-      dispatch({
-        type: PlayerActionTypes.PLAYER_PLAY
-      });
+      play();
     }, 200);
   };
 

--- a/components/Player/PreviousButton/PreviousButton.tsx
+++ b/components/Player/PreviousButton/PreviousButton.tsx
@@ -6,20 +6,17 @@
 import type React from 'react';
 import { useContext } from 'react';
 import PlayerContext from '@contexts/PlayerContext';
-import { PlayerActionTypes } from '@states/player/Player.actions';
 import IconButton from '@components/IconButton';
 import PreviousIcon from '@svg/icons/Previous.svg';
 
-export interface INextButtonProps
+export interface IPreviousButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
-const PreviousButton: React.FC<INextButtonProps> = ({ ...props }) => {
-  const { dispatch } = useContext(PlayerContext);
+const PreviousButton: React.FC<IPreviousButtonProps> = ({ ...props }) => {
+  const { previousTrack } = useContext(PlayerContext);
 
   const handleClick = () => {
-    dispatch({
-      type: PlayerActionTypes.PLAYER_PREVIOUS_TRACK
-    });
+    previousTrack();
   };
 
   return (

--- a/components/Player/ReplayButton/ReplayButton.tsx
+++ b/components/Player/ReplayButton/ReplayButton.tsx
@@ -6,7 +6,6 @@
 import type React from 'react';
 import { useContext } from 'react';
 import PlayerContext from '@contexts/PlayerContext';
-import { PlayerActionTypes } from '@states/player/Player.actions';
 import IconButton from '@components/IconButton';
 import ReplayIcon from '@svg/icons/Replay.svg';
 
@@ -14,13 +13,10 @@ export interface IReplayButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 const ReplayButton: React.FC<IReplayButtonProps> = ({ ...props }) => {
-  const { audioElm, dispatch } = useContext(PlayerContext);
+  const { seekBy } = useContext(PlayerContext);
 
   const handleClick = () => {
-    dispatch({
-      type: PlayerActionTypes.PLAYER_UPDATE_CURRENT_TIME,
-      payload: Math.max(audioElm.currentTime - 5, 0)
-    });
+    seekBy(-5);
   };
 
   return (

--- a/interfaces/contexts/IPlayerContext.ts
+++ b/interfaces/contexts/IPlayerContext.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 /**
  * @file IStateContext.ts
  * Interface for player context. Extends IStateContext and props specific to
@@ -9,4 +10,14 @@ import type { IStateContext } from './IStateContext';
 export interface IPlayerContext extends IStateContext {
   audioElm: HTMLAudioElement;
   imageUrl: string;
+  play(): void;
+  pause(): void;
+  togglePlayPause(): void;
+  toggleMute(): void;
+  seekTo(time: number): void;
+  seekBy(time: number): void;
+  seekToRelative(time: number): void;
+  nextTrack(): void;
+  previousTrack(): void;
+  setTrack(index: number): void;
 }

--- a/interfaces/embed/IEmbedConfig.ts
+++ b/interfaces/embed/IEmbedConfig.ts
@@ -2,6 +2,8 @@
  * Defines embed config interfaces and types.
  */
 
+import { ParsedUrlQuery } from 'querystring';
+
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // !! If these change ALL EXISTING EMBEDS WILL BREAK !!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -9,7 +11,7 @@
 /**
  * Parameter object keys expected from requests.
  */
-export interface IEmbedParams {
+export interface IEmbedParams extends ParsedUrlQuery {
   /**
    * Use to override title initially shown in player.
    */

--- a/interfaces/embed/IEmbedConfig.ts
+++ b/interfaces/embed/IEmbedConfig.ts
@@ -13,73 +13,73 @@ export interface IEmbedParams {
   /**
    * Use to override title initially shown in player.
    */
-  tt?: string;
+  tt?: string | string[];
 
   /**
    * Use to override subtitle of all audio items.
    */
-  ts?: string;
+  ts?: string | string[];
 
   /**
    * Use to override audio url of initially loaded audio.
    */
-  ua?: string;
+  ua?: string | string[];
 
   /**
    * Use to override URL of image initial shown as player background.
    */
-  ui?: string;
+  ui?: string | string[];
 
   /**
    * Use to override URL of image initial shown as thumbnail in player.
    */
-  ue?: string;
+  ue?: string | string[];
 
   /**
    * Use to provide URL for RSS feed data.
    */
-  uf?: string;
+  uf?: string | string[];
 
   /**
    * Guid of episode in feed items to use for initial audio in player.
    */
-  ge?: string;
+  ge?: string | string[];
 
   /**
    * Use to override subscription URL when it should differ
    * from data source RSS feed provided by `uf` or when `ua` is used
    * without `uf`.
    */
-  us?: string;
+  us?: string | string[];
 
   /**
    * Target window to open subscription URL in.
    */
-  gs?: string;
+  gs?: string | string[];
 
   /**
    * Use to indicate a playlist should be shown. Set to an integer value
    * for the number of items to include in playlist, or `all` to include
    * everything in the feed. Requires RSS feed URL be provided with `uf`.
    */
-  sp?: string;
+  sp?: string | string[];
 
   /**
    * Use to filter playlist items by episode season. Requires `sp` and `uf`
    * values be provided.
    */
-  se?: string;
+  se?: string | string[];
 
   /**
    * Use to filter playlist items by single category. Requires `sp` and `uf`
    * values be provided.
    */
-  ct?: string;
+  ct?: string | string[];
 
   /**
    * Use to feature episode image as large cover art.
    */
-  ca?: string;
+  ca?: string | string[];
 
   /**
    * Provide a custom accent color.
@@ -90,25 +90,25 @@ export interface IEmbedParams {
    * DEPRECATED
    * Use to set call to action text.
    */
-  tc?: string;
+  tc?: string | string[];
 
   /**
    * DEPRECATED
    * Use to provide a call to action URL.
    */
-  uc?: string;
+  uc?: string | string[];
 
   /**
    * DEPRECATED
    * Target window to open call to action URL in.
    */
-  gc?: string;
+  gc?: string | string[];
 
   /**
    * DEPRECATED
    * Use to provide the ID of a RSS feed.
    */
-  if?: string;
+  if?: string | string[];
 }
 
 /**

--- a/interfaces/states/player/IPlayerState.ts
+++ b/interfaces/states/player/IPlayerState.ts
@@ -25,4 +25,14 @@ export interface IPlayerState {
    * Holds all the audio data that can be played.
    */
   tracks: IAudioData[];
+
+  /**
+   * Current volume of the player as a value between 0 and 1.
+   */
+  volume: number;
+
+  /**
+   * Boolean to mute player.
+   */
+  muted: boolean;
 }

--- a/lib/generate/string/generateEmbedUrl.ts
+++ b/lib/generate/string/generateEmbedUrl.ts
@@ -9,9 +9,16 @@ import parseEmbedConfigToParams from '@lib/parse/config/parseEmbedConfigToParams
 
 const generateEmbedUrl = (config: IEmbedConfig) => {
   const embedUrlHost = typeof window !== 'undefined' && window.location.origin;
-  const embedUrlParams = new URLSearchParams({
-    ...parseEmbedConfigToParams(config)
-  });
+  const urlSearchPrams = Object.entries(
+    parseEmbedConfigToParams(config)
+  ).reduce(
+    (a, [k, v]) => [
+      ...a,
+      ...(Array.isArray(v) ? v.map((cv) => [k, cv]) : [[k, v]])
+    ],
+    [] as string[][]
+  );
+  const embedUrlParams = new URLSearchParams(urlSearchPrams);
 
   embedUrlParams.sort();
 

--- a/lib/parse/config/parseEmbedParamsToConfig.spec.ts
+++ b/lib/parse/config/parseEmbedParamsToConfig.spec.ts
@@ -1,15 +1,16 @@
+import { IEmbedParams } from '@interfaces/embed/IEmbedConfig';
 import parseEmbedParamsToConfig from './parseEmbedParamsToConfig';
 
 describe('lib/parse/config', () => {
   describe('parseEmbedParamsToConfig', () => {
-    const params = {
+    const params: IEmbedParams = {
       tt: 'TT',
       ts: 'TS',
       tc: 'TC',
       ua: 'UA',
       ui: 'UI',
       ue: 'UE',
-      uf: 'UF',
+      uf: ['UF', 'UF2'],
       if: 'IF',
       ge: 'GE',
       uc: 'UC',

--- a/lib/parse/config/parseEmbedParamsToConfig.ts
+++ b/lib/parse/config/parseEmbedParamsToConfig.ts
@@ -17,25 +17,28 @@ const parseEmbedParamsToConfig = (params: IEmbedParams): IEmbedConfig => {
     (a, c: [keyof IEmbedParams, string]) => {
       const [k, v] = c;
       const prop = EmbedParamKeysMap.get(k);
+      const normalizeValue = (val: string | string[]) =>
+        Array.isArray(val) ? val[0] : val;
 
       if (prop) {
         switch (prop) {
           case 'showPlaylist':
             return {
               ...a,
-              [prop]: v === 'all' ? v : convertStringToInteger(v)
+              [prop]:
+                v === 'all' ? v : convertStringToInteger(normalizeValue(v))
             };
 
           case 'playlistSeason':
             return {
               ...a,
-              [prop]: convertStringToInteger(v)
+              [prop]: convertStringToInteger(normalizeValue(v))
             };
 
           case 'showCoverArt':
             return {
               ...a,
-              [prop]: convertStringToBoolean(v)
+              [prop]: convertStringToBoolean(normalizeValue(v))
             };
 
           case 'accentColor':
@@ -55,7 +58,7 @@ const parseEmbedParamsToConfig = (params: IEmbedParams): IEmbedConfig => {
           default:
             return {
               ...a,
-              [prop]: v
+              [prop]: normalizeValue(v)
             };
         }
       }

--- a/lib/parse/config/parseEmbedParamsToConfig.ts
+++ b/lib/parse/config/parseEmbedParamsToConfig.ts
@@ -13,60 +13,56 @@ import convertStringToInteger from '@lib/convert/string/convertStringToInteger';
  * @returns Embed Config object
  */
 const parseEmbedParamsToConfig = (params: IEmbedParams): IEmbedConfig => {
-  const config: IEmbedConfig = Object.entries(params).reduce(
-    (a, c: [keyof IEmbedParams, string]) => {
-      const [k, v] = c;
-      const prop = EmbedParamKeysMap.get(k);
-      const normalizeValue = (val: string | string[]) =>
-        Array.isArray(val) ? val[0] : val;
+  const config: IEmbedConfig = Object.entries(params).reduce((a, c) => {
+    const [k, v] = c;
+    const prop = EmbedParamKeysMap.get(k as keyof IEmbedParams);
+    const normalizeValue = (val: string | string[]) =>
+      Array.isArray(val) ? val[0] : val;
 
-      if (prop) {
-        switch (prop) {
-          case 'showPlaylist':
-            return {
-              ...a,
-              [prop]:
-                v === 'all' ? v : convertStringToInteger(normalizeValue(v))
-            };
+    if (prop) {
+      switch (prop) {
+        case 'showPlaylist':
+          return {
+            ...a,
+            [prop]: v === 'all' ? v : convertStringToInteger(normalizeValue(v))
+          };
 
-          case 'playlistSeason':
-            return {
-              ...a,
-              [prop]: convertStringToInteger(normalizeValue(v))
-            };
+        case 'playlistSeason':
+          return {
+            ...a,
+            [prop]: convertStringToInteger(normalizeValue(v))
+          };
 
-          case 'showCoverArt':
-            return {
-              ...a,
-              [prop]: convertStringToBoolean(normalizeValue(v))
-            };
+        case 'showCoverArt':
+          return {
+            ...a,
+            [prop]: convertStringToBoolean(normalizeValue(v))
+          };
 
-          case 'accentColor':
-            return {
-              ...a,
-              [prop]: (Array.isArray(v) ? (v as string[]) : [v])
-                .map((ac) =>
-                  /^[a-f0-9]{2}[a-f0-9]{2}[a-f0-9]{2}(?:[a-f0-9]{2})?(?:\s1?\d?\d%)?$/i.test(
-                    ac
-                  )
-                    ? `#${ac}`
-                    : null
+        case 'accentColor':
+          return {
+            ...a,
+            [prop]: (Array.isArray(v) ? (v as string[]) : [v])
+              .map((ac) =>
+                /^[a-f0-9]{2}[a-f0-9]{2}[a-f0-9]{2}(?:[a-f0-9]{2})?(?:\s1?\d?\d%)?$/i.test(
+                  ac
                 )
-                .filter((ac) => !!ac)
-            };
+                  ? `#${ac}`
+                  : null
+              )
+              .filter((ac) => !!ac)
+          };
 
-          default:
-            return {
-              ...a,
-              [prop]: normalizeValue(v)
-            };
-        }
+        default:
+          return {
+            ...a,
+            [prop]: normalizeValue(v)
+          };
       }
+    }
 
-      return a;
-    },
-    {} as IEmbedConfig
-  );
+    return a;
+  }, {} as IEmbedConfig);
 
   return config;
 };

--- a/pages/embed.tsx
+++ b/pages/embed.tsx
@@ -167,6 +167,20 @@ const EmbedPage = ({ config, data }: IEmbedPageProps) => {
                     <PrxLogo className={styles.logoPrx} />
                   </div>
 
+                  <div className={styles.menuToggle}>
+                    <IconButton
+                      type="button"
+                      className={clsx(styles.iconButton, styles.moreButton)}
+                      onClick={handleMoreButtonClick}
+                    >
+                      {!showMenu ? (
+                        <MoreHorizIcon aria-label="Show menu" />
+                      ) : (
+                        <CloseIcon aria-label="Close menu" />
+                      )}
+                    </IconButton>
+                  </div>
+
                   <div className={styles.panel}>
                     <div className={clsx(styles.controls, menuShownClass)}>
                       {canShowPlaylist && (
@@ -229,20 +243,6 @@ const EmbedPage = ({ config, data }: IEmbedPageProps) => {
 
                   <div className={styles.progress}>
                     <PlayerProgress />
-                  </div>
-
-                  <div className={styles.menuToggle}>
-                    <IconButton
-                      type="button"
-                      className={clsx(styles.iconButton, styles.moreButton)}
-                      onClick={handleMoreButtonClick}
-                    >
-                      {!showMenu ? (
-                        <MoreHorizIcon aria-label="Show menu" />
-                      ) : (
-                        <CloseIcon aria-label="Close menu" />
-                      )}
-                    </IconButton>
                   </div>
                 </div>
               </div>

--- a/states/player/Player.reducer.spec.ts
+++ b/states/player/Player.reducer.spec.ts
@@ -198,5 +198,72 @@ describe('states/player', () => {
         expect(result.tracks[0]).toStrictEqual(mockTrack);
       });
     });
+
+    describe('`muted` actions', () => {
+      test('should set `muted` to true', () => {
+        const result = playerStateReducer(
+          {
+            ...playerInitialState
+          },
+          {
+            type: PlayerActionTypes.PLAYER_MUTE
+          }
+        );
+
+        expect(result.muted).toBe(true);
+      });
+
+      test('should set `muted` to false', () => {
+        const result = playerStateReducer(
+          {
+            ...playerInitialState,
+            muted: true
+          },
+          {
+            type: PlayerActionTypes.PLAYER_UNMUTE
+          }
+        );
+
+        expect(result.muted).toBe(false);
+      });
+
+      test('should toggle `muted`', () => {
+        const result1 = playerStateReducer(
+          {
+            ...playerInitialState
+          },
+          {
+            type: PlayerActionTypes.PLAYER_TOGGLE_MUTED
+          }
+        );
+        const result2 = playerStateReducer(
+          {
+            ...result1
+          },
+          {
+            type: PlayerActionTypes.PLAYER_TOGGLE_MUTED
+          }
+        );
+
+        expect(result1.muted).toBe(true);
+        expect(result2.muted).toBe(false);
+      });
+    });
+
+    describe('`volume` actions', () => {
+      test('should set `volume`', () => {
+        const result = playerStateReducer(
+          {
+            ...playerInitialState
+          },
+          {
+            type: PlayerActionTypes.PLAYER_UPDATE_VOLUME,
+            payload: 0.25
+          }
+        );
+
+        expect(result.volume).toBe(0.25);
+      });
+    });
   });
 });

--- a/states/player/Player.reducer.ts
+++ b/states/player/Player.reducer.ts
@@ -13,14 +13,16 @@ export const playerInitialState: IPlayerState = {
   playing: false,
   currentTrackIndex: 0,
   tracks: null,
-  currentTime: null
+  currentTime: null,
+  muted: false,
+  volume: 0.8
 };
 
 export const playerStateReducer = (
   state: IPlayerState,
   action: IPlayerAction
 ): IPlayerState => {
-  const { playing, currentTrackIndex, tracks } = state;
+  const { playing, currentTrackIndex, tracks, muted } = state;
 
   switch (action.type) {
     case ActionTypes.PLAYER_PLAY:
@@ -52,6 +54,17 @@ export const playerStateReducer = (
 
     case ActionTypes.PLAYER_UPDATE_CURRENT_TIME:
       return { ...state, currentTime: action.payload };
+    case ActionTypes.PLAYER_MUTE:
+      return { ...state, muted: true };
+
+    case ActionTypes.PLAYER_UNMUTE:
+      return { ...state, muted: false };
+
+    case ActionTypes.PLAYER_TOGGLE_MUTED:
+      return { ...state, muted: !muted };
+
+    case ActionTypes.PLAYER_UPDATE_VOLUME:
+      return { ...state, volume: action.payload };
 
     default:
       return state;

--- a/styles/Embed.module.scss
+++ b/styles/Embed.module.scss
@@ -187,7 +187,7 @@ $background-blur: 30px;
 
   line-height: 0;
 
-  --iconButton-size: clamp(20px, 14vw, 40px);
+  --iconButton-size: clamp(20px, 12vw, 40px);
   --playButton-size: clamp(40px, 20vw, 60px);
 }
 

--- a/styles/Embed.module.scss
+++ b/styles/Embed.module.scss
@@ -14,8 +14,8 @@ $player-corner-radius: 10px;
 $player-padding: 20px;
 $player-text-color: $white;
 
-$playerThumbnail-size--mobile: 65px;
-$playerThumbnail-size: 135px;
+$player-thumbnail-size--mobile: 65px;
+$player-thumbnail-size: 135px;
 
 // TODO: Move to background module.
 $background-tint-color: hsl(0 0% 0%);
@@ -26,8 +26,8 @@ $background-blur: 30px;
   --divider-color: #{$divider-color};
   --divider-size: #{$divider-size};
 
-  --playerThumbnail-size--mobile: #{$playerThumbnail-size--mobile};
-  --playerThumbnail-size: #{$playerThumbnail-size};
+  --player-thumbnail-size--mobile: #{$player-thumbnail-size--mobile};
+  --player-thumbnail-size: #{$player-thumbnail-size};
 
   // TODO: Move to background module.
   --background-tint-alpha: #{$background-tint-alpha};
@@ -129,13 +129,13 @@ $background-blur: 30px;
 }
 
 .playerMain {
-  --playerThumbnail-size: #{$playerThumbnail-size--mobile};
+  --player-thumbnail-size: #{$player-thumbnail-size--mobile};
 
   display: grid;
-  grid-template-columns: var(--playerThumbnail-size) 1fr max-content;
+  grid-template-columns: var(--player-thumbnail-size) 1fr max-content;
   grid-template-rows: max-content 1fr max-content;
   grid-template-areas:
-    'THUMB TEXT  MTOG'
+    'THUMB TEXT  LOGO'
     'PANEL PANEL PANEL'
     'PROG  PROG  PROG';
   align-content: stretch;
@@ -146,7 +146,7 @@ $background-blur: 30px;
 
   .withCoverArt & {
     grid-template-areas:
-      'TEXT  TEXT  MTOG'
+      'TEXT  TEXT  LOGO'
       'PANEL PANEL PANEL'
       'PROG  PROG  PROG';
   }
@@ -156,8 +156,8 @@ $background-blur: 30px;
   grid-area: THUMB;
 
   display: grid;
-  width: var(--playerThumbnail-size);
-  height: var(--playerThumbnail-size);
+  width: var(--player-thumbnail-size);
+  height: var(--player-thumbnail-size);
 }
 
 .text {
@@ -202,6 +202,8 @@ $background-blur: 30px;
 }
 
 .menu {
+  grid-area: MENU;
+
   display: none;
   align-items: center;
   gap: 5px;
@@ -214,7 +216,7 @@ $background-blur: 30px;
 }
 
 .menuToggle {
-  grid-area: MTOG;
+  grid-area: LOGO;
 }
 
 .progress {
@@ -231,21 +233,45 @@ $background-blur: 30px;
   gap: 5px;
 }
 
+@media only screen and (min-width: #{600px - $player-thumbnail-size}) {
+  .main.withCoverArt {
+    .text {
+      gap: $player-gap;
+    }
+
+    .logo {
+      display: block;
+    }
+
+    .panel {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .controls {
+      &.menuShown {
+        display: block;
+      }
+    }
+
+    .menu {
+      display: flex;
+    }
+
+    .menuToggle {
+      display: none;
+    }
+  }
+}
+
 @media only screen and (min-width: 600px) {
   .playerMain {
-    --playerThumbnail-size: #{$playerThumbnail-size};
+    --player-thumbnail-size: #{$player-thumbnail-size};
 
     grid-template-areas:
       'THUMB TEXT  LOGO'
       'THUMB PANEL PANEL'
       'PROG  PROG  PROG';
-
-    .withCoverArt & {
-      grid-template-areas:
-        'TEXT  TEXT  LOGO'
-        'PANEL PANEL PANEL'
-        'PROG  PROG  PROG';
-    }
   }
 
   .text {
@@ -269,7 +295,6 @@ $background-blur: 30px;
 
   .menu {
     display: flex;
-    grid-area: MENU;
   }
 
   .menuToggle {


### PR DESCRIPTION
Closes #33 

- Adds hotkey controls
  - Spacebar: Toggle play/pause or trigger focused button
  - J : Seek back 10 seconds
  - K : Toggle play/pause
  - L : Seek forward 10 seconds
  - Left : Seek back 5 seconds
  - Right : Seek forward 5 seconds
  - Comma : Seek back 1/30th second
  - Period : Seek forward 1/30th second
  - Home : Seek to start
  - End : Seek to end
  - 1-9: Seek to percentage of pressed key (multiples of 10)
  - 0 : Seek to start
  - [ : Previous track
  - ] : Next track
  - M : Mute volume
  - Up : Increase volume by 5%
  - Down : Decrease volume by 5%
- Adjusted when controls layout change while cover art is shown.

## To Review

- [ ] Checkout Branch.
- [ ] Run `nvm use`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to http://localhost:3000/e?uf=http://feed.songexploder.net/SongExploder&sp=35.

> ...then...

- [x] Try all the hotkeys.
- [x] Tab focus control buttons.
- [x] Press spacebar on each and ensure that keypress triggers the button actions.
- [x] Resize window down till control's layout changes.
- [x] Note the change happens just as icons get close, with some padding to keep controls separate from menu.
- [x] Add `&ca=1` to URL.
- [x] Resize window down till control's layout changes.
- [x] Note the change happens just as  control icons take up horizontal width.
