### PR TITLE
#14: Share modal buttons

### DIFF
--- a/components/IconButton/IconButton.module.scss
+++ b/components/IconButton/IconButton.module.scss
@@ -14,9 +14,10 @@
 }
 
 .iconButton {
-  width: calc(var(--iconButton-size) + var(--iconButton-padding));
-  height: calc(var(--iconButton-size) + var(--iconButton-padding));
   display: grid;
+  grid-template-columns: var(--iconButton-size);
+  grid-template-rows: var(--iconButton-size);
+  place-items: stretch;
   overflow: hidden;
 
   padding: var(--iconButton-padding);
@@ -28,6 +29,10 @@
 
   > svg {
     fill: currentColor;
+  }
+
+  > svg[class*='fa-'] {
+    padding: var(--iconButton-padding);
   }
 
   &:active {

--- a/components/Player/CopyLinkButton/CopyLinkButton.tsx
+++ b/components/Player/CopyLinkButton/CopyLinkButton.tsx
@@ -1,0 +1,33 @@
+/**
+ * @file CopyLinkButton.tsx
+ * Button to copy link for current track to clipboard.
+ */
+
+import type React from 'react';
+import { useContext } from 'react';
+import PlayerContext from '@contexts/PlayerContext';
+import MenuButton from '@components/MenuButton';
+import LinkIcon from '@svg/icons/Link.svg';
+
+export interface ICopyLinkButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const CopyLinkButton: React.FC<ICopyLinkButtonProps> = ({ className }) => {
+  const { state } = useContext(PlayerContext);
+  const { currentTrackIndex, tracks } = state;
+  const { link } = tracks[currentTrackIndex];
+
+  return (
+    <MenuButton
+      className={className}
+      action="clipboard"
+      label="Link"
+      type="button"
+      clipboardText={link}
+    >
+      <LinkIcon />
+    </MenuButton>
+  );
+};
+
+export default CopyLinkButton;

--- a/components/Player/CopyLinkButton/index.ts
+++ b/components/Player/CopyLinkButton/index.ts
@@ -1,0 +1,3 @@
+import CopyLinkButton from './CopyLinkButton';
+
+export default CopyLinkButton;

--- a/components/Player/ShareEmailButton/ShareEmailButton.tsx
+++ b/components/Player/ShareEmailButton/ShareEmailButton.tsx
@@ -1,0 +1,38 @@
+/**
+ * @file ShareEmailButton.tsx
+ * Button to open share mailto link.
+ */
+
+import type React from 'react';
+import { useContext } from 'react';
+import PlayerContext from '@contexts/PlayerContext';
+import MenuButton from '@components/MenuButton';
+import EmailIcon from '@svg/icons/Email.svg';
+
+export interface IShareEmailButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const ShareEmailButton: React.FC<IShareEmailButtonProps> = ({ className }) => {
+  const { state } = useContext(PlayerContext);
+  const { currentTrackIndex, tracks } = state;
+  const { link, title } = tracks[currentTrackIndex];
+  const params = new URLSearchParams({
+    subject: title,
+    body: `Check out this podcast episode! ${link}`
+  });
+  const shareUrl = `mailto:?${params}`;
+
+  return (
+    <MenuButton
+      className={className}
+      action="link"
+      label="Share via email"
+      type="button"
+      linkHref={shareUrl}
+    >
+      <EmailIcon />
+    </MenuButton>
+  );
+};
+
+export default ShareEmailButton;

--- a/components/Player/ShareEmailButton/ShareEmailButton.tsx
+++ b/components/Player/ShareEmailButton/ShareEmailButton.tsx
@@ -20,7 +20,7 @@ const ShareEmailButton: React.FC<IShareEmailButtonProps> = ({ className }) => {
     subject: title,
     body: `Check out this podcast episode! ${link}`
   });
-  const shareUrl = `mailto:?${params}`;
+  const shareUrl = `mailto:?${params}`.replaceAll('+', ' ');
 
   return (
     <MenuButton

--- a/components/Player/ShareEmailButton/index.ts
+++ b/components/Player/ShareEmailButton/index.ts
@@ -1,0 +1,3 @@
+import ShareEmailButton from './ShareEmailButton';
+
+export default ShareEmailButton;

--- a/components/Player/ShareFacebookButton/ShareFacebookButton.tsx
+++ b/components/Player/ShareFacebookButton/ShareFacebookButton.tsx
@@ -22,7 +22,7 @@ const ShareFacebookButton: React.FC<IShareFacebookButtonProps> = ({
   const params = new URLSearchParams({
     u: link
   });
-  const shareUrl = encodeURI(`http://www.facebook.com/sharer.php?${params}`);
+  const shareUrl = `http://www.facebook.com/sharer.php?${params}`;
 
   return (
     <MenuButton

--- a/components/Player/ShareFacebookButton/ShareFacebookButton.tsx
+++ b/components/Player/ShareFacebookButton/ShareFacebookButton.tsx
@@ -1,0 +1,40 @@
+/**
+ * @file ShareFacebookButton.tsx
+ * Button to open share link for Facebook.
+ */
+
+import type React from 'react';
+import { useContext } from 'react';
+import PlayerContext from '@contexts/PlayerContext';
+import MenuButton from '@components/MenuButton';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFacebookF } from '@fortawesome/free-brands-svg-icons';
+
+export interface IShareFacebookButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const ShareFacebookButton: React.FC<IShareFacebookButtonProps> = ({
+  className
+}) => {
+  const { state } = useContext(PlayerContext);
+  const { currentTrackIndex, tracks } = state;
+  const { link } = tracks[currentTrackIndex];
+  const params = new URLSearchParams({
+    u: link
+  });
+  const shareUrl = encodeURI(`http://www.facebook.com/sharer.php?${params}`);
+
+  return (
+    <MenuButton
+      className={className}
+      action="link"
+      label="Share on Facebook"
+      type="button"
+      linkHref={shareUrl}
+    >
+      <FontAwesomeIcon icon={faFacebookF} />
+    </MenuButton>
+  );
+};
+
+export default ShareFacebookButton;

--- a/components/Player/ShareFacebookButton/index.ts
+++ b/components/Player/ShareFacebookButton/index.ts
@@ -1,0 +1,3 @@
+import ShareFacebookButton from './ShareFacebookButton';
+
+export default ShareFacebookButton;

--- a/components/Player/ShareTwitterButton/ShareTwitterButton.tsx
+++ b/components/Player/ShareTwitterButton/ShareTwitterButton.tsx
@@ -1,0 +1,41 @@
+/**
+ * @file ShareTwitterButton.tsx
+ * Button to open share link for Twitter.
+ */
+
+import type React from 'react';
+import { useContext } from 'react';
+import PlayerContext from '@contexts/PlayerContext';
+import MenuButton from '@components/MenuButton';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTwitter } from '@fortawesome/free-brands-svg-icons';
+
+export interface IShareTwitterButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const ShareTwitterButton: React.FC<IShareTwitterButtonProps> = ({
+  className
+}) => {
+  const { state } = useContext(PlayerContext);
+  const { currentTrackIndex, tracks } = state;
+  const { link, title } = tracks[currentTrackIndex];
+  const params = new URLSearchParams({
+    url: link,
+    text: title
+  });
+  const shareUrl = `https://twitter.com/share?${params}`;
+
+  return (
+    <MenuButton
+      className={className}
+      action="link"
+      label="Share on Twitter"
+      type="button"
+      linkHref={shareUrl}
+    >
+      <FontAwesomeIcon icon={faTwitter} />
+    </MenuButton>
+  );
+};
+
+export default ShareTwitterButton;

--- a/components/Player/ShareTwitterButton/index.ts
+++ b/components/Player/ShareTwitterButton/index.ts
@@ -1,0 +1,3 @@
+import ShareTwitterButton from './ShareTwitterButton';
+
+export default ShareTwitterButton;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
-    "@fortawesome/free-solid-svg-icons": "^6.1.1",
+    "@fortawesome/free-brands-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
     "@styled-icons/fa-brands": "^10.38.0",
     "@svgr/webpack": "^6.2.1",

--- a/pages/embed.tsx
+++ b/pages/embed.tsx
@@ -26,6 +26,10 @@ import PlayButton from '@components/Player/PlayButton';
 import PlayerProgress from '@components/Player/PlayerProgress';
 import MenuButton from '@components/MenuButton';
 import IconButton from '@components/IconButton';
+import CopyLinkButton from '@components/Player/CopyLinkButton';
+import ShareFacebookButton from '@components/Player/ShareFacebookButton';
+import ShareTwitterButton from '@components/Player/ShareTwitterButton';
+import ShareEmailButton from '@components/Player/ShareEmailButton';
 import PrxLogo from '@svg/prx-logo.svg';
 import MoreHorizIcon from '@svg/icons/MoreHoriz.svg';
 import CloseIcon from '@svg/icons/Close.svg';
@@ -33,8 +37,6 @@ import AddIcon from '@svg/icons/Add.svg';
 import ShareIcon from '@svg/icons/Share.svg';
 import FavoriteIcon from '@svg/icons/Favorite.svg';
 import CodeIcon from '@svg/icons/Code.svg';
-import EmailIcon from '@svg/icons/Email.svg';
-import LinkIcon from '@svg/icons/Link.svg';
 import styles from '@styles/Embed.module.scss';
 
 // Define dynamic component imports.
@@ -59,7 +61,7 @@ export interface IEmbedPageProps {
 
 const EmbedPage = ({ config, data }: IEmbedPageProps) => {
   const { showCoverArt, showPlaylist, accentColor } = config;
-  const { audio, playlist, bgImageUrl, shareUrl, owner } = data;
+  const { audio, playlist, bgImageUrl } = data;
   const { imageUrl } = audio || {};
   const [state, dispatch] = useReducer(embedStateReducer, embedInitialState);
   const { shareShown, followShown, supportShown } = state;
@@ -252,43 +254,33 @@ const EmbedPage = ({ config, data }: IEmbedPageProps) => {
                   <Playlist style={{ height: '100%' }} />
                 </div>
               )}
+
+              {shareShown && (
+                <Modal onClose={handleShareCloseClick}>
+                  <nav className={styles.modalMenu}>
+                    <ShareFacebookButton />
+
+                    <ShareTwitterButton />
+
+                    <ShareEmailButton />
+
+                    <CopyLinkButton />
+
+                    <MenuButton
+                      action="clipboard"
+                      clipboardText={embedHtml}
+                      label="Embed Code"
+                    >
+                      <CodeIcon />
+                    </MenuButton>
+                  </nav>
+                </Modal>
+              )}
             </Player>
           )}
 
           {followShown && (
             <Modal onClose={handleFollowCloseClick}>Follow Menu</Modal>
-          )}
-
-          {shareShown && (
-            <Modal onClose={handleShareCloseClick}>
-              <nav className={styles.modalMenu}>
-                {owner?.email && (
-                  <MenuButton
-                    action="link"
-                    linkHref={`mailto:${owner.email}`}
-                    label={`Email ${owner.name}`}
-                  >
-                    <EmailIcon />
-                  </MenuButton>
-                )}
-
-                <MenuButton
-                  action="clipboard"
-                  clipboardText={shareUrl}
-                  label="Link"
-                >
-                  <LinkIcon />
-                </MenuButton>
-
-                <MenuButton
-                  action="clipboard"
-                  clipboardText={embedHtml}
-                  label="Embed Code"
-                >
-                  <CodeIcon />
-                </MenuButton>
-              </nav>
-            </Modal>
           )}
 
           {supportShown && (

--- a/styles/Embed.module.scss
+++ b/styles/Embed.module.scss
@@ -233,7 +233,7 @@ $background-blur: 30px;
   gap: 5px;
 }
 
-@media only screen and (min-width: #{600px - $player-thumbnail-size}) {
+@media only screen and (min-width: #{640px - $player-thumbnail-size}) {
   .main.withCoverArt {
     .text {
       gap: $player-gap;
@@ -264,7 +264,7 @@ $background-blur: 30px;
   }
 }
 
-@media only screen and (min-width: 600px) {
+@media only screen and (min-width: 640px) {
   .playerMain {
     --player-thumbnail-size: #{$player-thumbnail-size};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,10 +1117,10 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.1.1"
 
-"@fortawesome/free-solid-svg-icons@^6.1.1":
+"@fortawesome/free-brands-svg-icons@^6.1.1":
   version "6.1.1"
-  resolved "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz"
-  integrity sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.1.1.tgz#3580961d4f42bd51dc171842402f23a18a5480b1"
+  integrity sha512-mFbI/czjBZ+paUtw5NPr2IXjun5KAC8eFqh1hnxowjA4mMZxWz4GCIksq6j9ZSa6Uxj9JhjjDVEd77p2LN2Blg==
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.1.1"
 


### PR DESCRIPTION
Closes #14 

- add share buttons for fb, tw, and email
- add copy link button
- add fa icon styling to icon button

## To Review

- [x] Checkout Branch.
- [x] Run `nvm use`.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to http://localhost:3000/e?uf=http://feed.songexploder.net/SongExploder&sp=35.

> ...then...

- [x] Open share menu.
- [x] Ensure Facebook, Twitter, and Email buttons open new tab to share link to current episode URL.
- [x] Ensure Copy Link button copies link for current episode URL
- [x] Change tracks.
- [x] Ensure all buttons tested above now share or copy the URL for the episode now shown.
