### PR TITLE
#40: Add `_from` param to audio URL's

### DIFF
--- a/lib/generate/string/generateAudioUrl.spec.ts
+++ b/lib/generate/string/generateAudioUrl.spec.ts
@@ -1,0 +1,19 @@
+import generateAudioUrl from './generateAudioUrl';
+
+describe('lib/generate/string', () => {
+  describe('generateAudioUrl', () => {
+    test('should append `_from` param.', () => {
+      const result = generateAudioUrl('http://foo.com/bar.mp3');
+
+      expect(result).toMatch('http://foo.com/bar.mp3?_from=play.prx.org');
+    });
+
+    test('should preserve `_from` param.', () => {
+      const result = generateAudioUrl(
+        'http://foo.com/bar.mp3?_from=AcmePlayer'
+      );
+
+      expect(result).toMatch('http://foo.com/bar.mp3?_from=AcmePlayer');
+    });
+  });
+});

--- a/lib/generate/string/generateAudioUrl.ts
+++ b/lib/generate/string/generateAudioUrl.ts
@@ -1,0 +1,18 @@
+/**
+ * @file generateAudioUrl.ts
+ *
+ * Generate audio URL from passed URL. Append `_from` param when not
+ * already included.
+ */
+
+const generateAudioUrl = (audioUrl: string) => {
+  const url = new URL(audioUrl);
+
+  if (!url.searchParams.get('_from')) {
+    url.searchParams.set('_from', 'play.prx.org');
+  }
+
+  return url.toString();
+};
+
+export default generateAudioUrl;

--- a/lib/parse/data/parseAudioData.spec.ts
+++ b/lib/parse/data/parseAudioData.spec.ts
@@ -5,15 +5,15 @@ describe('lib/parse/data', () => {
   describe('parseAudioData', () => {
     const mockRssItem: IRssItem = {
       guid: 'foo-bar',
-      link: '//foo.com/foo-bar',
+      link: 'http://foo.com/foo-bar',
       title: 'foo',
       enclosure: {
-        url: '//foo.com/audio.mp3'
+        url: 'http://foo.com/audio.mp3'
       },
       categories: ['cat1', '  cat2', 'cat3   '],
       itunes: {
         subtitle: 'bar',
-        image: '//foo.com/image.png',
+        image: 'http://foo.com/image.png',
         season: '42',
         duration: '12:34',
         explicit: 'true'
@@ -25,12 +25,12 @@ describe('lib/parse/data', () => {
 
       expect(result).toStrictEqual({
         guid: 'foo-bar',
-        link: '//foo.com/foo-bar',
+        link: 'http://foo.com/foo-bar',
         title: 'foo',
-        url: '//foo.com/audio.mp3',
+        url: 'http://foo.com/audio.mp3?_from=play.prx.org',
         categories: ['cat1', 'cat2', 'cat3'],
         subtitle: 'bar',
-        imageUrl: '//foo.com/image.png',
+        imageUrl: 'http://foo.com/image.png',
         season: 42,
         duration: '12:34',
         explicit: true
@@ -44,11 +44,11 @@ describe('lib/parse/data', () => {
 
       expect(result).toStrictEqual({
         guid: 'foo-bar',
-        link: '//foo.com/foo-bar',
+        link: 'http://foo.com/foo-bar',
         title: 'foo',
-        url: '//foo.com/audio.mp3',
+        url: 'http://foo.com/audio.mp3?_from=play.prx.org',
         subtitle: 'bar',
-        imageUrl: '//foo.com/image.png',
+        imageUrl: 'http://foo.com/image.png',
         season: 42,
         duration: '12:34',
         explicit: true
@@ -62,9 +62,9 @@ describe('lib/parse/data', () => {
 
       expect(result).toStrictEqual({
         guid: 'foo-bar',
-        link: '//foo.com/foo-bar',
+        link: 'http://foo.com/foo-bar',
         title: 'foo',
-        url: '//foo.com/audio.mp3',
+        url: 'http://foo.com/audio.mp3?_from=play.prx.org',
         categories: ['cat1', 'cat2', 'cat3']
       });
     });
@@ -76,11 +76,11 @@ describe('lib/parse/data', () => {
 
       expect(result).toStrictEqual({
         guid: 'foo-bar',
-        link: '//foo.com/foo-bar',
+        link: 'http://foo.com/foo-bar',
         title: 'foo',
         categories: ['cat1', 'cat2', 'cat3'],
         subtitle: 'bar',
-        imageUrl: '//foo.com/image.png',
+        imageUrl: 'http://foo.com/image.png',
         season: 42,
         duration: '12:34',
         explicit: true

--- a/lib/parse/data/parseAudioData.ts
+++ b/lib/parse/data/parseAudioData.ts
@@ -1,6 +1,7 @@
 import type { IAudioData, IRssItem } from '@interfaces/data';
 import convertStringToBoolean from '@lib/convert/string/convertStringToBoolean';
 import convertStringToInteger from '@lib/convert/string/convertStringToInteger';
+import generateAudioUrl from '@lib/generate/string/generateAudioUrl';
 
 const parseAudioData = ({
   guid,
@@ -12,7 +13,7 @@ const parseAudioData = ({
 }: IRssItem): IAudioData => ({
   guid,
   link,
-  ...(enclosure && { url: enclosure.url }),
+  ...(enclosure && { url: generateAudioUrl(enclosure.url) }),
   ...(categories && {
     categories: categories.map((v) => v.replace(/^\s+|\s+$/g, ''))
   }),

--- a/lib/parse/data/parseEmbedData.spec.ts
+++ b/lib/parse/data/parseEmbedData.spec.ts
@@ -6,12 +6,12 @@ describe('lib/parse/data', () => {
   describe('parseEmbedData', () => {
     const mockRssData: Parser.Output<IRssItem> = {
       image: {
-        url: '//foo.com/foo.png'
+        url: 'http://foo.com/foo.png'
       },
       title: 'Foo',
-      link: '//foo.com',
+      link: 'http://foo.com',
       itunes: {
-        image: '//foo.com/foo-3000.png',
+        image: 'http://foo.com/foo-3000.png',
         owner: {
           name: 'John Doe',
           email: 'email@address.com'
@@ -20,29 +20,29 @@ describe('lib/parse/data', () => {
       items: [
         {
           guid: 'foo-bar',
-          link: '//foo.com/foo-bar',
+          link: 'http://foo.com/foo-bar',
           title: 'Foo Bar',
           categories: ['foo', 'bar'],
           enclosure: {
-            url: '//foo.com/foo-bar.mp3'
+            url: 'http://foo.com/foo-bar.mp3?_from=play.prx.org'
           },
           itunes: {
             subtitle: 'Foo to the bar.',
-            image: '//foo.com/foo-bar.png',
+            image: 'http://foo.com/foo-bar.png',
             season: '1'
           }
         },
         {
           guid: 'foo-baz',
-          link: '//foo.com/foo-baz',
+          link: 'http://foo.com/foo-baz',
           title: 'Foo Baz',
           categories: ['foo', 'baz'],
           enclosure: {
-            url: '//foo.com/foo-baz.mp3'
+            url: 'http://foo.com/foo-baz.mp3?_from=play.prx.org'
           },
           itunes: {
             subtitle: 'Foo to the baz.',
-            image: '//foo.com/foo-baz.png',
+            image: 'http://foo.com/foo-baz.png',
             season: '2'
           }
         }
@@ -53,22 +53,22 @@ describe('lib/parse/data', () => {
       const result = parseEmbedData({
         title: 'Foo',
         subtitle: 'Foo to the bar',
-        audioUrl: '//foo.com/foo.mp3',
-        imageUrl: '//foo.com/bg.png',
-        epImageUrl: '//foo.com/foo.png',
-        subscribeUrl: '//foo.com/feed.rss'
+        audioUrl: 'http://foo.com/foo.mp3',
+        imageUrl: 'http://foo.com/bg.png',
+        epImageUrl: 'http://foo.com/foo.png',
+        subscribeUrl: 'http://foo.com/feed.rss'
       });
 
       expect(result).toStrictEqual({
-        bgImageUrl: '//foo.com/bg.png',
+        bgImageUrl: 'http://foo.com/bg.png',
         audio: {
           title: 'Foo',
           subtitle: 'Foo to the bar',
-          url: '//foo.com/foo.mp3',
-          imageUrl: '//foo.com/foo.png'
+          url: 'http://foo.com/foo.mp3?_from=play.prx.org',
+          imageUrl: 'http://foo.com/foo.png'
         },
         followUrls: {
-          rss: '//foo.com/feed.rss'
+          rss: 'http://foo.com/feed.rss'
         }
       });
       expect(result.playlist).toBeUndefined();
@@ -77,27 +77,27 @@ describe('lib/parse/data', () => {
 
     test('should use first item as audio data', () => {
       const result = parseEmbedData(
-        { feedUrl: '//foo.com/feed.rss' },
+        { feedUrl: 'http://foo.com/feed.rss' },
         mockRssData
       );
 
       expect(result).toStrictEqual({
-        bgImageUrl: '//foo.com/foo.png',
+        bgImageUrl: 'http://foo.com/foo.png',
         audio: {
           guid: 'foo-bar',
-          link: '//foo.com/foo-bar',
-          url: '//foo.com/foo-bar.mp3',
+          link: 'http://foo.com/foo-bar',
+          url: 'http://foo.com/foo-bar.mp3?_from=play.prx.org',
           title: 'Foo Bar',
           subtitle: 'Foo',
-          imageUrl: '//foo.com/foo-bar.png',
+          imageUrl: 'http://foo.com/foo-bar.png',
           categories: ['foo', 'bar'],
           season: 1
         },
         followUrls: {
-          rss: '//foo.com/feed.rss'
+          rss: 'http://foo.com/feed.rss'
         },
         rssTitle: 'Foo',
-        shareUrl: '//foo.com/foo-bar',
+        shareUrl: 'http://foo.com/foo-bar',
         owner: {
           name: 'John Doe',
           email: 'email@address.com'
@@ -107,27 +107,27 @@ describe('lib/parse/data', () => {
 
     test('should use item matching config guid as audio data', () => {
       const result = parseEmbedData(
-        { feedUrl: '//foo.com/feed.rss', episodeGuid: 'foo-baz' },
+        { feedUrl: 'http://foo.com/feed.rss', episodeGuid: 'foo-baz' },
         mockRssData
       );
 
       expect(result).toStrictEqual({
-        bgImageUrl: '//foo.com/foo.png',
+        bgImageUrl: 'http://foo.com/foo.png',
         audio: {
           guid: 'foo-baz',
-          link: '//foo.com/foo-baz',
-          url: '//foo.com/foo-baz.mp3',
+          link: 'http://foo.com/foo-baz',
+          url: 'http://foo.com/foo-baz.mp3?_from=play.prx.org',
           title: 'Foo Baz',
           subtitle: 'Foo',
-          imageUrl: '//foo.com/foo-baz.png',
+          imageUrl: 'http://foo.com/foo-baz.png',
           categories: ['foo', 'baz'],
           season: 2
         },
         followUrls: {
-          rss: '//foo.com/feed.rss'
+          rss: 'http://foo.com/feed.rss'
         },
         rssTitle: 'Foo',
-        shareUrl: '//foo.com/foo-baz',
+        shareUrl: 'http://foo.com/foo-baz',
         owner: {
           name: 'John Doe',
           email: 'email@address.com'
@@ -137,27 +137,27 @@ describe('lib/parse/data', () => {
 
     test('should use first item as audio data when config guid is not in items', () => {
       const result = parseEmbedData(
-        { feedUrl: '//foo.com/feed.rss', episodeGuid: 'not-there' },
+        { feedUrl: 'http://foo.com/feed.rss', episodeGuid: 'not-there' },
         mockRssData
       );
 
       expect(result).toStrictEqual({
-        bgImageUrl: '//foo.com/foo.png',
+        bgImageUrl: 'http://foo.com/foo.png',
         audio: {
           guid: 'foo-bar',
-          link: '//foo.com/foo-bar',
-          url: '//foo.com/foo-bar.mp3',
+          link: 'http://foo.com/foo-bar',
+          url: 'http://foo.com/foo-bar.mp3?_from=play.prx.org',
           title: 'Foo Bar',
           subtitle: 'Foo',
-          imageUrl: '//foo.com/foo-bar.png',
+          imageUrl: 'http://foo.com/foo-bar.png',
           categories: ['foo', 'bar'],
           season: 1
         },
         followUrls: {
-          rss: '//foo.com/feed.rss'
+          rss: 'http://foo.com/feed.rss'
         },
         rssTitle: 'Foo',
-        shareUrl: '//foo.com/foo-bar',
+        shareUrl: 'http://foo.com/foo-bar',
         owner: {
           name: 'John Doe',
           email: 'email@address.com'
@@ -167,39 +167,39 @@ describe('lib/parse/data', () => {
 
     test('should include a full playlist', () => {
       const result = parseEmbedData(
-        { feedUrl: '//foo.com/feed.rss', showPlaylist: 'all' },
+        { feedUrl: 'http://foo.com/feed.rss', showPlaylist: 'all' },
         mockRssData
       );
 
       expect(result.playlist).toStrictEqual([
         {
           guid: 'foo-bar',
-          link: '//foo.com/foo-bar',
-          url: '//foo.com/foo-bar.mp3',
+          link: 'http://foo.com/foo-bar',
+          url: 'http://foo.com/foo-bar.mp3?_from=play.prx.org',
           title: 'Foo Bar',
           subtitle: 'Foo',
-          imageUrl: '//foo.com/foo-bar.png',
+          imageUrl: 'http://foo.com/foo-bar.png',
           categories: ['foo', 'bar'],
           season: 1
         },
         {
           guid: 'foo-baz',
-          link: '//foo.com/foo-baz',
-          url: '//foo.com/foo-baz.mp3',
+          link: 'http://foo.com/foo-baz',
+          url: 'http://foo.com/foo-baz.mp3?_from=play.prx.org',
           title: 'Foo Baz',
           subtitle: 'Foo',
-          imageUrl: '//foo.com/foo-baz.png',
+          imageUrl: 'http://foo.com/foo-baz.png',
           categories: ['foo', 'baz'],
           season: 2
         }
       ] as IAudioData[]);
-      expect(result.shareUrl).toBe('//foo.com');
+      expect(result.shareUrl).toBe('http://foo.com');
     });
 
     test('should filter playlist by season', () => {
       const result = parseEmbedData(
         {
-          feedUrl: '//foo.com/feed.rss',
+          feedUrl: 'http://foo.com/feed.rss',
           showPlaylist: 'all',
           playlistSeason: 2
         },
@@ -209,11 +209,11 @@ describe('lib/parse/data', () => {
       expect(result.playlist).toStrictEqual([
         {
           guid: 'foo-baz',
-          link: '//foo.com/foo-baz',
-          url: '//foo.com/foo-baz.mp3',
+          link: 'http://foo.com/foo-baz',
+          url: 'http://foo.com/foo-baz.mp3?_from=play.prx.org',
           title: 'Foo Baz',
           subtitle: 'Foo',
-          imageUrl: '//foo.com/foo-baz.png',
+          imageUrl: 'http://foo.com/foo-baz.png',
           categories: ['foo', 'baz'],
           season: 2
         }
@@ -223,7 +223,7 @@ describe('lib/parse/data', () => {
     test('should filter playlist by category', () => {
       const result = parseEmbedData(
         {
-          feedUrl: '//foo.com/feed.rss',
+          feedUrl: 'http://foo.com/feed.rss',
           showPlaylist: 'all',
           playlistCategory: 'baz'
         },
@@ -233,11 +233,11 @@ describe('lib/parse/data', () => {
       expect(result.playlist).toStrictEqual([
         {
           guid: 'foo-baz',
-          link: '//foo.com/foo-baz',
-          url: '//foo.com/foo-baz.mp3',
+          link: 'http://foo.com/foo-baz',
+          url: 'http://foo.com/foo-baz.mp3?_from=play.prx.org',
           title: 'Foo Baz',
           subtitle: 'Foo',
-          imageUrl: '//foo.com/foo-baz.png',
+          imageUrl: 'http://foo.com/foo-baz.png',
           categories: ['foo', 'baz'],
           season: 2
         }
@@ -247,7 +247,7 @@ describe('lib/parse/data', () => {
     test('should limit playlist length', () => {
       const result = parseEmbedData(
         {
-          feedUrl: '//foo.com/feed.rss',
+          feedUrl: 'http://foo.com/feed.rss',
           showPlaylist: 1
         },
         mockRssData
@@ -256,11 +256,11 @@ describe('lib/parse/data', () => {
       expect(result.playlist).toStrictEqual([
         {
           guid: 'foo-bar',
-          link: '//foo.com/foo-bar',
-          url: '//foo.com/foo-bar.mp3',
+          link: 'http://foo.com/foo-bar',
+          url: 'http://foo.com/foo-bar.mp3?_from=play.prx.org',
           title: 'Foo Bar',
           subtitle: 'Foo',
-          imageUrl: '//foo.com/foo-bar.png',
+          imageUrl: 'http://foo.com/foo-bar.png',
           categories: ['foo', 'bar'],
           season: 1
         }
@@ -272,12 +272,12 @@ describe('lib/parse/data', () => {
       delete rssData.image;
       const result = parseEmbedData(
         {
-          feedUrl: '//foo.com/feed.rss'
+          feedUrl: 'http://foo.com/feed.rss'
         },
         rssData
       );
 
-      expect(result.bgImageUrl).toBe('//foo.com/foo-3000.png');
+      expect(result.bgImageUrl).toBe('http://foo.com/foo-3000.png');
     });
 
     test('should fallback to audio image for background image', () => {
@@ -286,12 +286,12 @@ describe('lib/parse/data', () => {
       delete rssData.itunes;
       const result = parseEmbedData(
         {
-          feedUrl: '//foo.com/feed.rss'
+          feedUrl: 'http://foo.com/feed.rss'
         },
         rssData
       );
 
-      expect(result.bgImageUrl).toBe('//foo.com/foo-bar.png');
+      expect(result.bgImageUrl).toBe('http://foo.com/foo-bar.png');
     });
   });
 });

--- a/lib/parse/data/parseEmbedData.spec.ts
+++ b/lib/parse/data/parseEmbedData.spec.ts
@@ -24,7 +24,7 @@ describe('lib/parse/data', () => {
           title: 'Foo Bar',
           categories: ['foo', 'bar'],
           enclosure: {
-            url: 'http://foo.com/foo-bar.mp3?_from=play.prx.org'
+            url: 'http://foo.com/foo-bar.mp3'
           },
           itunes: {
             subtitle: 'Foo to the bar.',
@@ -38,7 +38,7 @@ describe('lib/parse/data', () => {
           title: 'Foo Baz',
           categories: ['foo', 'baz'],
           enclosure: {
-            url: 'http://foo.com/foo-baz.mp3?_from=play.prx.org'
+            url: 'http://foo.com/foo-baz.mp3'
           },
           itunes: {
             subtitle: 'Foo to the baz.',

--- a/lib/parse/data/parseEmbedData.ts
+++ b/lib/parse/data/parseEmbedData.ts
@@ -1,6 +1,7 @@
 import type { IAudioData, IEmbedData, IRssItem } from '@interfaces/data';
 import type { IEmbedConfig } from '@interfaces/embed/IEmbedConfig';
 import type Parser from 'rss-parser';
+import generateAudioUrl from '@lib/generate/string/generateAudioUrl';
 import parseAudioData from './parseAudioData';
 
 const parseEmbedData = (
@@ -54,7 +55,7 @@ const parseEmbedData = (
     // Override with values from config.
     ...(configTitle && { title: configTitle }),
     ...(configSubtitle && { subtitle: configSubtitle }),
-    ...(configAudioUrl && { url: configAudioUrl }),
+    ...(configAudioUrl && { url: generateAudioUrl(configAudioUrl) }),
     ...(configImageUrl && { imageUrl: configImageUrl })
   };
   const audioHasProps = Object.keys(audio).length > 0;


### PR DESCRIPTION
Closes #40 

- Adds `_from=play.prx.org` to audio URL's that do not already have a `_from` param.

## To Review

- [ ] Checkout Branch.
- [ ] Run `nvm use`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to [localhost:3000](https://localhost:3000).

> ...then...

- [ ] Inspect network requests for media.
- [ ] Ensure initial requests for audio include `_from` query string param with a value of `play.prx.org`.
- [ ] Run `yarn test --coverage`.
- [ ] Ensure all tests pass with 💯 . 
