### PR TITLE
#44: Content aware layout switching

### DIFF
--- a/components/Modal/Modal.module.scss
+++ b/components/Modal/Modal.module.scss
@@ -1,10 +1,12 @@
 @import '@styles/colors';
 
 $modal-background-color: $black-a-90;
+$modal-background-blur: 8px;
 $modal-text-color: $white;
 
 :export {
   --modal-background-color: #{$modal-background-color};
+  --modal-background-blur: #{$modal-background-blur};
   --modal-text-color: #{$modal-text-color};
 }
 
@@ -16,6 +18,7 @@ $modal-text-color: $white;
   display: grid;
   place-content: center;
   color: var(--modal-text-color);
+  backdrop-filter: blur(var(--modal-background-blur, 0));
 }
 
 .closeButton {

--- a/components/Player/Player.tsx
+++ b/components/Player/Player.tsx
@@ -135,11 +135,12 @@ const Player: React.FC<IPlayerProps> = ({
   };
 
   const updateMediaSession = useCallback(() => {
+    const artworkSrc = currentTrack.imageUrl || imageUrl;
     if ('mediaSession' in navigator) {
       navigator.mediaSession.metadata = new window.MediaMetadata({
         title: currentTrack.title,
         artist: currentTrack.subtitle,
-        artwork: [{ src: currentTrack.imageUrl }]
+        ...(artworkSrc && { artwork: [{ src: artworkSrc }] })
       });
       navigator.mediaSession.setActionHandler('play', () => {
         play();
@@ -172,6 +173,7 @@ const Player: React.FC<IPlayerProps> = ({
     currentTrack.subtitle,
     currentTrack.title,
     forward,
+    imageUrl,
     replay,
     seekTo,
     tracks.length

--- a/components/Player/PlayerThumbnail/PlayerThumbnail.tsx
+++ b/components/Player/PlayerThumbnail/PlayerThumbnail.tsx
@@ -5,31 +5,44 @@
 
 import type React from 'react';
 import { useContext } from 'react';
-import PrxImage from '@components/PrxImage';
+import clsx from 'clsx';
 import PlayerContext from '@contexts/PlayerContext';
+import PrxImage, { IPrxImageProps } from '@components/PrxImage';
 import ThemeVars from '@components/ThemeVars';
 import styles from './PlayerThumbnail.module.scss';
 
-export interface IPlayerThumbnailProps {
-  sizes?: string;
+export interface IPlayerThumbnailProps extends Partial<IPrxImageProps> {
+  imageClassName?: string;
 }
 
-const PlayerThumbnail: React.FC<IPlayerThumbnailProps> = ({ sizes }) => {
+const PlayerThumbnail: React.FC<IPlayerThumbnailProps> = ({
+  className,
+  imageClassName,
+  layout = 'fill',
+  width,
+  height,
+  ...props
+}) => {
   const { state, imageUrl: defaultImageUrl } = useContext(PlayerContext);
   const { tracks, currentTrackIndex } = state;
   const { imageUrl, title } = tracks[currentTrackIndex];
+  const srcUrl = imageUrl || defaultImageUrl;
 
   return (
-    imageUrl && (
-      <div className={styles.root}>
+    srcUrl && (
+      <div className={clsx(styles.root, className)}>
         <ThemeVars theme="PlayerThumbnail" cssProps={styles} />
         <PrxImage
-          className={styles.image}
-          src={imageUrl || defaultImageUrl}
+          src={srcUrl}
           alt={`Thumbnail for "${title}".`}
-          layout="fill"
-          sizes={sizes}
+          layout={layout}
+          {...(layout !== 'fill' && {
+            width,
+            height
+          })}
           priority
+          {...props}
+          className={clsx(styles.image, imageClassName)}
         />
       </div>
     )

--- a/components/Player/Playlist/Playlist.tsx
+++ b/components/Player/Playlist/Playlist.tsx
@@ -8,6 +8,7 @@ import type React from 'react';
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import convertDurationStringToIntegerArray from '@lib/convert/string/convertDurationStringToIntegerArray';
+import convertSecondsToDuration from '@lib/convert/string/convertSecondsToDuration';
 import formatDurationParts from '@lib/format/time/formatDurationParts';
 import sumDurationParts from '@lib/math/time/sumDurationParts';
 import PlayerContext from '@contexts/PlayerContext';
@@ -88,6 +89,10 @@ const Playlist: React.FC<IPlaylistProps> = ({ className, ...props }) => {
             {tracks.map((track, index) => {
               const { guid, title, imageUrl, duration, explicit } = track;
               const thumbSrc = imageUrl || defaultThumbUrl;
+              const trackDuration =
+                duration.indexOf(':') !== -1
+                  ? duration
+                  : convertSecondsToDuration(parseInt(duration, 10));
               return (
                 <button
                   type="button"
@@ -121,7 +126,7 @@ const Playlist: React.FC<IPlaylistProps> = ({ className, ...props }) => {
                       />
                     </span>
                   )}
-                  <span className={styles.trackDuration}>{duration}</span>
+                  <span className={styles.trackDuration}>{trackDuration}</span>
                 </button>
               );
             })}

--- a/components/PrxImage/PrxImage.module.scss
+++ b/components/PrxImage/PrxImage.module.scss
@@ -1,0 +1,19 @@
+.wrapper {
+  display: block;
+  position: absolute;
+  inset: 0;
+  box-sizing: border-box;
+}
+
+.image {
+  display: block;
+  position: absolute;
+  inset: 0;
+  box-sizing: border-box;
+  width: 0;
+  height: 0;
+  min-width: 100%;
+  min-height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+}

--- a/components/PrxImage/PrxImage.tsx
+++ b/components/PrxImage/PrxImage.tsx
@@ -7,24 +7,62 @@ import type React from 'react';
 import type { ImageProps } from 'next/image';
 import Image from 'next/image';
 import isTrustedImageDomain from '@lib/validate/isTrustedImageDomain';
+import styles from './PrxImage.module.scss';
 
 export interface IPrxImageProps extends ImageProps {}
+
+const renderImage = ({
+  src,
+  alt,
+  priority,
+  layout,
+  lazyRoot,
+  objectFit,
+  ...other
+}: IPrxImageProps) => {
+  if (layout !== 'raw')
+    return (
+      <div className={styles.wrapper}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          className={styles.image}
+          src={src as string}
+          alt={alt}
+          style={{ objectFit }}
+          {...other}
+        />
+      </div>
+    );
+
+  // eslint-disable-next-line @next/next/no-img-element
+  return <img src={src as string} alt={alt} {...other} />;
+};
 
 const PrxImage: React.FC<IPrxImageProps> = ({
   src,
   alt,
   priority,
   layout,
+  lazyRoot,
   ...other
 }) => {
   const isUrlString = typeof src === 'string';
   const isTrusted = isUrlString && isTrustedImageDomain(src as string);
+  const nextImageProps = {
+    lazyRoot,
+    priority,
+    layout
+  };
 
   return isTrusted || !isUrlString ? (
-    <Image src={src} alt={alt} priority={priority} layout={layout} {...other} />
+    <Image src={src} alt={alt} {...nextImageProps} {...other} />
   ) : (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img src={src} alt={alt} {...other} />
+    renderImage({
+      src,
+      alt,
+      layout,
+      ...other
+    })
   );
 };
 

--- a/lib/parse/data/parseAudioData.ts
+++ b/lib/parse/data/parseAudioData.ts
@@ -11,7 +11,7 @@ const parseAudioData = ({
   categories
 }: IRssItem): IAudioData => ({
   guid,
-  link,
+  ...(link && { link }),
   ...(enclosure && { url: enclosure.url }),
   ...(categories && {
     categories: categories.map((v) => v.replace(/^\s+|\s+$/g, ''))

--- a/lib/parse/data/parseEmbedData.spec.ts
+++ b/lib/parse/data/parseEmbedData.spec.ts
@@ -293,5 +293,23 @@ describe('lib/parse/data', () => {
 
       expect(result.bgImageUrl).toBe('//foo.com/foo-bar.png');
     });
+
+    test('should set rss link on audio when items do not have links', () => {
+      const rssData = {
+        ...mockRssData
+      };
+      delete rssData.items[0].link;
+      const result = parseEmbedData(
+        {
+          feedUrl: '//foo.com/feed.rss',
+          showPlaylist: 'all'
+        },
+        rssData
+      );
+
+      expect(result.audio.link).toBe('//foo.com');
+      expect(result.playlist[0].link).toBe('//foo.com');
+      expect(result.playlist[1].link).toBe('//foo.com/foo-baz');
+    });
   });
 });

--- a/lib/parse/data/parseEmbedData.ts
+++ b/lib/parse/data/parseEmbedData.ts
@@ -32,6 +32,7 @@ const parseEmbedData = (
   const audioItems =
     rssItems &&
     rssItems.map((i) => ({
+      link: rssShareUrl,
       ...parseAudioData(i as IRssItem),
       // Use feed title as audio items' subtitle.
       subtitle: rssTitle

--- a/pages/embed.tsx
+++ b/pages/embed.tsx
@@ -6,7 +6,7 @@
 import type { GetServerSideProps } from 'next';
 import type { IEmbedData } from '@interfaces/data';
 import type { IEmbedConfig } from '@interfaces/embed/IEmbedConfig';
-import { useReducer, useState } from 'react';
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 import Head from 'next/head';
 import dynamic from 'next/dynamic';
 import clsx from 'clsx';
@@ -66,6 +66,12 @@ const EmbedPage = ({ config, data }: IEmbedPageProps) => {
   const [state, dispatch] = useReducer(embedStateReducer, embedInitialState);
   const { shareShown, followShown, supportShown } = state;
   const [showMenu, setShowMenu] = useState(false);
+  const [playerLayout, setPlayerLayout] = useState<string>();
+  const playerMainRef = useRef<HTMLDivElement>();
+  const playerPanelRef = useRef<HTMLDivElement>();
+  const playerControlsRef = useRef<HTMLDivElement>();
+  const playerMenuRef = useRef<HTMLDivElement>();
+  const layoutBreakpoints = useRef<{ name: string; minWidth: number }[]>([]);
   const menuShownClass = clsx({ [styles.menuShown]: showMenu });
   const coverArtImage = imageUrl || bgImageUrl;
   const canShowCoverArt = showCoverArt && coverArtImage;
@@ -88,6 +94,46 @@ const EmbedPage = ({ config, data }: IEmbedPageProps) => {
         ]
       : [])
   ].join('');
+
+  /**
+   * Initialize our layout break points based on elements sizes.
+   *
+   * `compact` - default layout.
+   * `compact-full` - small logo, controls and menu.
+   * `extended-full` - large logo, controls and menu.
+   */
+  const initLayoutBreakpoints = useCallback(() => {
+    const playerControlsRect =
+      playerControlsRef.current.getBoundingClientRect();
+    const playerMenuRect = playerMenuRef.current.getBoundingClientRect();
+    const playerGap = parseInt(styles.playerGap, 10);
+    const minPanelWidth =
+      playerMenuRect.width + playerControlsRect.width + playerGap;
+    const thumbnailOffset = !canShowCoverArt
+      ? parseInt(styles['--player-thumbnail-size'], 10) + playerGap
+      : 0;
+    const breakpoints = [
+      { name: 'compact', minWidth: 0 },
+      { name: 'compact-full', minWidth: minPanelWidth },
+      { name: 'extended-full', minWidth: thumbnailOffset + minPanelWidth }
+    ].sort((a, b) => a.minWidth - b.minWidth);
+
+    layoutBreakpoints.current = breakpoints;
+  }, [canShowCoverArt]);
+
+  /**
+   * Update player layout by finding the last breakpoint with a min width the
+   * player element fits into.
+   */
+  const updatePlayerLayout = useCallback(() => {
+    const playerMainRect = playerMainRef.current.getBoundingClientRect();
+    const bestFit = layoutBreakpoints.current.reduce(
+      (a, c) => (playerMainRect.width > c.minWidth ? c : a),
+      layoutBreakpoints.current[0]
+    );
+
+    setPlayerLayout(bestFit.name);
+  }, []);
 
   const handleMoreButtonClick = () => {
     setShowMenu(!showMenu);
@@ -116,6 +162,31 @@ const EmbedPage = ({ config, data }: IEmbedPageProps) => {
   const handleSupportCloseClick = () => {
     dispatch({ type: EmbedActionTypes.EMBED_HIDE_SUPPORT_DIALOG });
   };
+
+  const handleResize = useCallback(() => {
+    updatePlayerLayout();
+  }, [updatePlayerLayout]);
+
+  /**
+   * Initialize layout breakpoints.
+   */
+  useEffect(() => {
+    setTimeout(() => {
+      initLayoutBreakpoints();
+      updatePlayerLayout();
+    }, 500);
+  }, [initLayoutBreakpoints, canShowCoverArt, updatePlayerLayout]);
+
+  /**
+   * Setup/clean up window events.
+   */
+  useEffect(() => {
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [handleResize]);
 
   return (
     <>
@@ -151,11 +222,15 @@ const EmbedPage = ({ config, data }: IEmbedPageProps) => {
                   />
                 </div>
 
-                <div className={styles.playerMain}>
+                <div
+                  ref={playerMainRef}
+                  className={styles.playerMain}
+                  data-layout={playerLayout}
+                >
                   {!canShowCoverArt && (
                     <div className={styles.thumbnail}>
                       <PlayerThumbnail
-                        sizes={`(min-width: 500px) ${styles['--player-thumbnail-size']}, ${styles['--player-thumbnail-size--mobile']}`}
+                      // sizes={`(min-width: 500px) ${styles['--player-thumbnail-size']}, ${styles['--player-thumbnail-size--mobile']}`}
                       />
                     </div>
                   )}
@@ -183,8 +258,11 @@ const EmbedPage = ({ config, data }: IEmbedPageProps) => {
                     </IconButton>
                   </div>
 
-                  <div className={styles.panel}>
-                    <div className={clsx(styles.controls, menuShownClass)}>
+                  <div ref={playerPanelRef} className={styles.panel}>
+                    <div
+                      ref={playerControlsRef}
+                      className={clsx(styles.controls, menuShownClass)}
+                    >
                       {canShowPlaylist && (
                         <PreviousButton
                           className={clsx(styles.button, styles.previousButton)}
@@ -212,8 +290,10 @@ const EmbedPage = ({ config, data }: IEmbedPageProps) => {
                       )}
                     </div>
 
-                    <div className={clsx(styles.menu, menuShownClass)}>
-                      {/* TODO: Replace content with dialog menu buttons. */}
+                    <div
+                      ref={playerMenuRef}
+                      className={clsx(styles.menu, menuShownClass)}
+                    >
                       <IconButton
                         type="button"
                         className={clsx(styles.menuButton, styles.followButton)}

--- a/styles/Embed.module.scss
+++ b/styles/Embed.module.scss
@@ -125,7 +125,12 @@ $background-blur: 30px;
     content: '';
     z-index: 1;
     background-color: hsl($h, $s, $l, $background-tint-alpha);
-    backdrop-filter: blur($background-blur);
+    backdrop-filter: blur(var(--background-blur));
+  }
+
+  & > img {
+    width: 100%;
+    height: 100%;
   }
 }
 

--- a/styles/Embed.module.scss
+++ b/styles/Embed.module.scss
@@ -23,6 +23,7 @@ $background-tint-alpha: 0.5;
 $background-blur: 30px;
 
 :export {
+  playerGap: #{$player-gap};
   --divider-color: #{$divider-color};
   --divider-size: #{$divider-size};
 
@@ -140,7 +141,9 @@ $background-blur: 30px;
     'PROG  PROG  PROG';
   align-content: stretch;
   gap: $player-gap;
-  padding: $player-padding;
+  margin: $player-padding;
+
+  visibility: hidden;
 
   color: $player-text-color;
 
@@ -149,6 +152,60 @@ $background-blur: 30px;
       'TEXT  TEXT  LOGO'
       'PANEL PANEL PANEL'
       'PROG  PROG  PROG';
+  }
+
+  &:where([data-layout]) {
+    visibility: visible;
+  }
+
+  &:where([data-layout='compact']) {
+    .logo {
+      display: none;
+    }
+    .menu {
+      display: none;
+    }
+    .panel {
+      --iconButton-size: clamp(20px, 12vw, 40px);
+      --playButton-size: clamp(40px, 20vw, 60px);
+    }
+  }
+
+  &:where([data-layout='compact-full'], [data-layout='extended-full']) {
+    .menuToggle {
+      display: none;
+    }
+    .panel {
+      justify-content: space-between;
+    }
+    .controls {
+      &.menuShown {
+        display: flex;
+      }
+    }
+    .menu {
+      &.menuShown {
+        display: flex;
+      }
+    }
+  }
+
+  &:where([data-layout^='extended']) {
+    --player-thumbnail-size: #{$player-thumbnail-size};
+
+    grid-template-areas:
+      'THUMB TEXT  LOGO'
+      'THUMB PANEL PANEL'
+      'PROG  PROG  PROG';
+  }
+
+  &:where([data-layout='extended']) {
+    .logo {
+      display: none;
+    }
+    .menu {
+      display: none;
+    }
   }
 }
 
@@ -165,7 +222,6 @@ $background-blur: 30px;
 }
 
 .logo {
-  display: none;
   grid-area: LOGO;
   align-self: start;
 }
@@ -180,15 +236,11 @@ $background-blur: 30px;
   grid-area: PANEL;
   align-self: center;
 
-  display: grid;
+  display: flex;
   justify-content: center;
-  align-items: center;
   gap: $player-gap;
 
   line-height: 0;
-
-  --iconButton-size: clamp(20px, 12vw, 40px);
-  --playButton-size: clamp(40px, 20vw, 60px);
 }
 
 .controls {
@@ -202,13 +254,9 @@ $background-blur: 30px;
 }
 
 .menu {
-  grid-area: MENU;
-
-  display: none;
+  display: flex;
   align-items: center;
   gap: 5px;
-
-  font-size: 1rem;
 
   &.menuShown {
     display: flex;
@@ -233,71 +281,71 @@ $background-blur: 30px;
   gap: 5px;
 }
 
-@media only screen and (min-width: #{640px - $player-thumbnail-size}) {
-  .main.withCoverArt {
-    .text {
-      gap: $player-gap;
-    }
+// @media only screen and (min-width: #{640px - $player-thumbnail-size}) {
+//   .main.withCoverArt {
+//     .text {
+//       gap: $player-gap;
+//     }
 
-    .logo {
-      display: block;
-    }
+//     .logo {
+//       display: block;
+//     }
 
-    .panel {
-      display: flex;
-      justify-content: space-between;
-    }
+//     .panel {
+//       display: flex;
+//       justify-content: space-between;
+//     }
 
-    .controls {
-      &.menuShown {
-        display: block;
-      }
-    }
+//     .controls {
+//       &.menuShown {
+//         display: block;
+//       }
+//     }
 
-    .menu {
-      display: flex;
-    }
+//     .menu {
+//       display: flex;
+//     }
 
-    .menuToggle {
-      display: none;
-    }
-  }
-}
+//     .menuToggle {
+//       display: none;
+//     }
+//   }
+// }
 
-@media only screen and (min-width: 640px) {
-  .playerMain {
-    --player-thumbnail-size: #{$player-thumbnail-size};
+// @media only screen and (min-width: 640px) {
+//   .playerMain {
+//     --player-thumbnail-size: #{$player-thumbnail-size};
 
-    grid-template-areas:
-      'THUMB TEXT  LOGO'
-      'THUMB PANEL PANEL'
-      'PROG  PROG  PROG';
-  }
+//     grid-template-areas:
+//       'THUMB TEXT  LOGO'
+//       'THUMB PANEL PANEL'
+//       'PROG  PROG  PROG';
+//   }
 
-  .text {
-    gap: $player-gap;
-  }
+//   .text {
+//     gap: $player-gap;
+//   }
 
-  .logo {
-    display: block;
-  }
+//   .logo {
+//     display: block;
+//   }
 
-  .panel {
-    display: flex;
-    justify-content: space-between;
-  }
+//   .panel {
+//     display: flex;
+//     justify-content: space-between;
+//   }
 
-  .controls {
-    &.menuShown {
-      display: block;
-    }
-  }
+//   .controls {
+//     &.menuShown {
+//       display: block;
+//     }
+//   }
 
-  .menu {
-    display: flex;
-  }
+//   .menu {
+//     display: flex;
+//   }
 
-  .menuToggle {
-    display: none;
-  }
-}
+//   .menuToggle {
+//     display: none;
+//   }
+// }


### PR DESCRIPTION
Closes #44 

- Player layout should change more smartly, favoring layouts that allow control and menu buttons to be visible at more screen sizes.

## To Review

- [x] Use the preview deployment: https://feat-44-smarter-layout-switching.d3dgwwqfox2y1t.amplifyapp.com/e?uf=http://feed.songexploder.net/SongExploder.

> ...or...

- [ ] Checkout Branch.
- [ ] Run `nvm use`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to http://localhost:3000/e?uf=http://feed.songexploder.net/SongExploder.

> ...then...

- [x] Resize window.
- [x] Ensure layout changes as controls run out of room.
- [x] Add `&ca=1` to URL.
- [x] Ensure layout changes happen as expected without the thumbnail shown.
- [x] Add `&sp=25` to URL.
- [x] Ensure layout changes as expected with the addition of prev/next track buttons.
- [x] Remove `&ca=1` from URL.
- [x] Ensure layout changes as expected with thumbnail shown with more control buttons.

> SIDE QUEST: Use the preview deploy domain to see how layouts work in your SE source clone.
